### PR TITLE
New address for longturn

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
           <br>
                 <h2>Freeciv elsewhere</h2>
                 One turn per day multiplayer games:
-                <a href="http://longturn.org/">Longturn.org</a>
+                <a href="http://longturn.net/">Longturn</a>
         </div>
       </div>
 


### PR DESCRIPTION
DNS games made longturn lose the longturn.org domain, they are now longturn.net.