### PR TITLE
Add links to SHA256 etc. to download.html

### DIFF
--- a/download.html
+++ b/download.html
@@ -79,6 +79,10 @@ To compile Freeciv yourself, download the source code:
 <a href="http://prdownloads.sourceforge.net/freeciv/freeciv-2.6.6.zip?download">Mirror 1 (sourceforge.net)</A><br>
 <a href="http://files.freeciv.org/stable/freeciv-2.6.6.zip">Mirror 2 (freeciv.org)</a><br></li>
 </ul>
+There are listings of checksums for these source code archives, current and past, at 
+<a href="http://files.freeciv.org/stable/SHA256SUM">http://files.freeciv.org/stable/SHA256SUM</a> and 
+<a href="http://files.freeciv.org/stable/SHA1SUM">SHA1SUM</a> and 
+<a href="http://files.freeciv.org/stable/MD5SUM">MD5SUM</a>.
 
 <h3>Windows Packages</h3>
 


### PR DESCRIPTION
Add a sentence to the Stable 2.6 / Source Code section, with HTML links to the files containing SHA256, SHA1, and MD5 checksum (digest) listings, hosted in http://files.freeciv.org/stable/SHA256SUM and sister files.