### PR TITLE
Fix bug tracker link in index.html subheadermenu

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
           <a href="http://www.freeciv.org/wiki/Interface_Language">Languages</a> |
           <a href="http://www.freeciv.org/wiki/People">Authors</a> |
           <a href="donate.html">Donate</a> | 
-          <a href="https://www.hostedredmine.com/projects/freeciv">Bug tracker</a> | 
+          <a href="https://osdn.net/projects/freeciv/ticket">Bug tracker</a> | 
           <a href="https://github.com/freeciv/">Freeciv Github</a> | 
           <a href="maillists.html">Mailing lists</a>  
         </div>


### PR DESCRIPTION
The "bug tracker" link on the freeciv.org/index.html page links to hostedredmine.com. I suspect that is a stale link. In the page, https://freeciv.fandom.com/wiki/How_to_Contribute , the ticket tracker links point to https://osdn.net/projects/freeciv/ticket . That appears to be the current link. This PR fixes exactly that front-page link to the bug tracker.